### PR TITLE
요청 추적기 CLS-rTracer 로깅 추적을 추가하기

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"cls-rtracer": "^2.6.3",
 				"dotenv": "^16.3.1",
 				"express": "^4.18.2",
 				"express-validator": "^7.0.1",
@@ -2836,6 +2837,17 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/cls-rtracer": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/cls-rtracer/-/cls-rtracer-2.6.3.tgz",
+			"integrity": "sha512-O7M/m2M/KfT9v+q7ka9nmsadS67ce9P8+1Zgm6VFamK56oFd1iCoJ9m8hYKUQpK4+RofyaexxHJlOBkxqCDs3Q==",
+			"dependencies": {
+				"uuid": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=12.17.0 <13.0.0 || >=13.14.0 <14.0.0 || >=14.0.0"
 			}
 		},
 		"node_modules/co": {
@@ -8315,6 +8327,18 @@
 			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/v8-to-istanbul": {

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
+		"cls-rtracer": "^2.6.3",
 		"dotenv": "^16.3.1",
 		"express": "^4.18.2",
 		"express-validator": "^7.0.1",
@@ -22,8 +23,8 @@
 		"mysql2": "^3.6.5",
 		"swagger-jsdoc": "^6.2.8",
 		"swagger-ui-express": "^5.0.0",
-		"winston-daily-rotate-file": "^4.7.1",
-		"winston": "^3.11.0"
+		"winston": "^3.11.0",
+		"winston-daily-rotate-file": "^4.7.1"
 	},
 	"devDependencies": {
 		"@swc/core": "^1.3.101",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,7 +1,10 @@
 import express from 'express';
+import rTracer from 'cls-rtracer';
 
 const app = express();
+
 app.use(express.json());
+app.use(rTracer.expressMiddleware());
 
 app.get('/', async (req, res) => {
   res.send('Hello World');

--- a/server/src/config/logger.js
+++ b/server/src/config/logger.js
@@ -1,18 +1,10 @@
 import * as winston from 'winston';
+
 import 'winston-daily-rotate-file';
 
-const {
-  combine, timestamp, printf, splat,
-} = winston.format;
+import rTracer from 'cls-rtracer';
 
-const logFormat = printf(
-  ({
-    level,
-    message,
-    label,
-    timestamp: time,
-  }) => `${time} [${label}] ${level}: ${message}`,
-);
+const { combine, timestamp } = winston.format;
 
 const transportsInfo = new winston.transports.DailyRotateFile({
   level: 'info',
@@ -46,9 +38,13 @@ const logger = winston.createLogger({
     timestamp({
       format: 'YYYY-MM-DD HH:mm:ss',
     }),
-    logFormat,
-    splat(),
+    winston.format.json(),
   ),
+  defaultMeta: {
+    get requestId() {
+      return rTracer.id();
+    },
+  },
   transports: [
     transportsInfo,
     transportsError,


### PR DESCRIPTION
## 요약
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

로깅 시스템에서 Http 요청 시 Id값을 추적하기 위해서 API 정보를 남겨야 합니다. 때문에 Trace-id가 필요합니다. 

npm 라이브러리 중 요청 추적기인 CLS-rTracer를 추가해서 Trace-id를 남길 수 있게 되었습니다.

이 라이브러리의 설명은 다음과 같습니다.
> 각 요청에 대한 ID로 UUID V1 값을 자동으로 생성하여 AsyncLocalStorage(CLS 핵심 API, 이 블로그 게시물 참조)에 저장합니다. 선택적으로 요청에 X-Request-Id 헤더가 포함된 경우 해당 값을 대신 사용합니다.
나중에 경로의 어느 곳에서나 생성된 요청 ID를 가져와 로깅이나 다른 용도로 사용할 수 있습니다

요청 API와 요청 되지 않는 API Id 값이 혼용이 되어 로그 기록의 일관성이 없는 문제가 발생했습니다. 기록을 정형화해서 저장해둘 필요가 있어 JSON 형태로 저장하도록 수정을 했습니다.

JSON 형태는 자주 쓰이는 데이터 형식으로 외부 로그 검색 시스템에 연계로 만드는 것이 용이하게 됩니다.

**seeAlso:**
- https://www.npmjs.com/package/cls-rtracer

## Pull Request 체크리스트

### TODO
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.

