### PR TITLE
시간 단위로 생기는 로그 파일을 수정하라

### DIFF
--- a/server/src/config/logger.ts
+++ b/server/src/config/logger.ts
@@ -9,7 +9,7 @@ const { combine, timestamp } = winston.format;
 const transportsInfo = new winston.transports.DailyRotateFile({
   level: 'info',
   filename: './logs/%DATE%.info.log',
-  datePattern: 'YYYY-MM-DD-HH',
+  datePattern: 'YYYY-MM-DD',
   zippedArchive: true,
   maxSize: '20m',
   maxFiles: '30d',
@@ -18,7 +18,7 @@ const transportsInfo = new winston.transports.DailyRotateFile({
 const transportsError = new winston.transports.DailyRotateFile({
   level: 'error',
   filename: './logs/%DATE%.error.log',
-  datePattern: 'YYYY-MM-DD-HH',
+  datePattern: 'YYYY-MM-DD',
   zippedArchive: true,
   maxSize: '20m',
   maxFiles: '14d',
@@ -27,7 +27,7 @@ const transportsError = new winston.transports.DailyRotateFile({
 const exceptionHandlers = new winston.transports.DailyRotateFile({
   level: 'error',
   filename: './logs/%DATE%.exception.log',
-  datePattern: 'YYYY-MM-DD-HH',
+  datePattern: 'YYYY-MM-DD',
   zippedArchive: true,
   maxSize: '20m',
   maxFiles: '14d',


### PR DESCRIPTION
## 요약
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
매 시간마다 로그 파일이 생깁니다. 이 프로젝트는 시간 단위로 정밀하게 할 필요가 없기 때문에 시간 단위 대신 일 단위로 파일 로그를 측정 하도록 수정했습니다

## Pull Request 체크리스트

### TODO
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.

