### PR TITLE
signup controller에 관심사 분리를 하라

### DIFF
--- a/server/src/auth/signup/application/signup.service.test.ts
+++ b/server/src/auth/signup/application/signup.service.test.ts
@@ -1,0 +1,35 @@
+import { save } from '../../domain/user.repository';
+import signupService from './signup.service';
+
+jest.mock('../../domain/user.repository.ts');
+
+describe('Signup service', () => {
+  const userMock = {
+    email: 'abc@gmail.com',
+    password: '12345',
+    name: '홍길동',
+  };
+
+  describe('signupService', () => {
+    beforeEach(() => {
+      (save as jest.Mock).mockResolvedValue(true);
+    });
+    context('회원 가입 정보가 주어지고 저장에 성공하면', () => {
+      it('true를 반환한다.', async () => {
+        const savedUser = await signupService(userMock.email, userMock.password, userMock.name);
+
+        expect(savedUser).toBe(true);
+      });
+    });
+
+    context('회원 가입 정보가 주어지고 저장에 실패하면', () => {
+      beforeEach(() => {
+        (save as jest.Mock).mockResolvedValue(false);
+      });
+      it('Error을 던져야 한다', async () => {
+        await expect(signupService(userMock.email, userMock.password, userMock.name))
+          .rejects.toThrow(new Error('중복된 항목이 있습니다.'));
+      });
+    });
+  });
+});

--- a/server/src/auth/signup/application/signup.service.ts
+++ b/server/src/auth/signup/application/signup.service.ts
@@ -1,0 +1,12 @@
+import { save } from '../../domain/user.repository';
+
+const signupService = async (email: string, password: string, name: string): Promise<boolean> => {
+  const savedUser = await save(email, password, name);
+  if (!savedUser) {
+    throw new Error('중복된 항목이 있습니다.');
+  }
+
+  return savedUser;
+};
+
+export default signupService;

--- a/server/src/auth/signup/web/signup.controller.test.ts
+++ b/server/src/auth/signup/web/signup.controller.test.ts
@@ -1,42 +1,39 @@
 import request from 'supertest';
 
 import app from '../../../app';
-import { save } from '../../domain/user.repository';
+import signupService from '../application/signup.service';
 
-jest.mock('../../domain/user.repository.ts');
+jest.mock('../application/signup.service.ts');
 
 describe('signup Controller', () => {
-  const email = 'abc@gmail.com';
-  const password = '12345';
+  const userMock = {
+    email: 'abc@gmail.com',
+    password: '1234',
+    name: '홍길동',
+  };
 
   describe('POST /signup', () => {
     context('회원 가입 정보가 주어지고 저장에 성공하면', () => {
       beforeEach(() => {
-        (save as jest.Mock).mockResolvedValue(() => true);
+        (signupService as jest.Mock).mockResolvedValue(true);
       });
       it('201 상태코드와 응답 메세지를 반환한다.', async () => {
-        const { statusCode, body } = await request(app).post('/signup').send({
-          email,
-          password,
-        });
+        const { statusCode, body: { messages: message } } = await request(app).post('/signup').send(userMock);
 
         expect(statusCode).toBe(201);
-        expect(body).toStrictEqual('회원 가입이 정상적으로 되었습니다.');
+        expect(message).toBe('회원 가입이 정상적으로 되었습니다.');
       });
     });
 
     context('회원 가입 정보가 주어지고 저장에 실패하면', () => {
       beforeEach(() => {
-        (save as jest.Mock).mockResolvedValue(() => false);
+        (signupService as jest.Mock).mockResolvedValue(false);
       });
       it('400 상태코드와 에러 메세지를 반환한다.', async () => {
-        const { statusCode, body } = await request(app).post('/signup').send({
-          email,
-          password,
-        });
+        const { statusCode, body: { messages } } = await request(app).post('/signup').send(userMock);
 
-        expect(statusCode).toBe(201);
-        expect(body).toStrictEqual('회원 가입이 정상적으로 되었습니다.');
+        expect(statusCode).toBe(400);
+        expect(messages).toBe('회원 가입에 실패했습니다.');
       });
     });
   });

--- a/server/src/auth/signup/web/signup.controller.ts
+++ b/server/src/auth/signup/web/signup.controller.ts
@@ -1,19 +1,21 @@
 import { Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
-import { save } from '../../domain/user.repository';
+import signupService from '../application/signup.service';
 
 const signupController = async (req: Request, res: Response) => {
   const { email, password, name } = req.body;
 
-  const registeredUser = await save(email, password, name);
+  const registeredUser = await signupService(email, password, name);
   if (!registeredUser) {
     return res.status(StatusCodes.BAD_REQUEST).json({
-      error: '중복된 항목이 있습니다.',
+      messages: '회원 가입에 실패했습니다.',
     });
   }
 
-  return res.status(StatusCodes.CREATED).json('회원 가입이 정상적으로 되었습니다.');
+  return res.status(StatusCodes.CREATED).json({
+    messages: '회원 가입이 정상적으로 되었습니다.',
+  });
 };
 
 export default signupController;


### PR DESCRIPTION
signup controller에서 데이터베이스 저장하는 로직과 http 요청 처리 하는
로직이 동시에 이뤄지고 있습니다.

이 경우 Got 클래스로 모든 일을 한 클래스에서 처리하는 패턴이 생깁니다.

기능이 추가 될 때마다 클래스가 역할은 가지고 있으면 복잡도가 올라갑니다.
때문에 관심사를 분리하고 레이어 계층 역할에 따른 코드 복잡도와 결합도를 낮췄습니다.

## 요약
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## Pull Request 체크리스트

### TODO
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.

