### PR TITLE
Pull Request 시 자동으로 Reviewer와 Assigness을 지정하라

### DIFF
--- a/.github/workflows/review-assign.yml
+++ b/.github/workflows/review-assign.yml
@@ -1,0 +1,15 @@
+name: Review Assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }} # assign pull request author
+          reviewers: foo, bar, baz # if draft, assigned when draft is released
+


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
Pull Request 시 자동으로 할당자와 검토자를 지정하도록 GitAction에
스크립트를 작성했습니다

## 링크 (Links)
- [Review Assign Action](https://github.com/marketplace/actions/review-assign-action)
## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요? 
- [x] PR 리뷰 가능한 크기를 유지하셨나요?

