### PR TITLE
타입스크립트 상대경로 옵션을 설정하라

### DIFF
--- a/server/.eslintrc.cjs
+++ b/server/.eslintrc.cjs
@@ -78,6 +78,7 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     'import/prefer-default-export': 'off',
+    'import/no-unresolved': [0, { commonjs: false }],
     'import/extensions': ['error', 'ignorePackages', {
       js: 'never',
       jsx: 'never',

--- a/server/jest.config.cjs
+++ b/server/jest.config.cjs
@@ -9,6 +9,9 @@ module.exports = {
   setupFiles: [
     'jest-plugin-context/setup',
   ],
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1',
+  },
   testPathIgnorePatterns: [
     '/node_modules/',
     'dist',

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -8,7 +8,13 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "esModuleInterop": true,
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "baseUrl": "./",
+    "paths": {
+      "src/*": [
+        "src/*"
+      ],
+    }
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## 작업 내용 (Content)
타입스크립트 패키지 구조에 상대경로로 바꾸는 작업을 했습니다

path 경로가 절대경로 지정되어 있어 path를 알아보기 힘들어 설정 옵션을
사용하여 간략하게 볼 수 있도록 지정했습니다.


## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요? 
- [x] PR 리뷰 가능한 크기를 유지하셨나요?

