### PR TITLE
Import 인라인에 type 한정자를 추가하라

### DIFF
--- a/server/.eslintrc.cjs
+++ b/server/.eslintrc.cjs
@@ -96,5 +96,12 @@ module.exports = {
         ],
       },
     ],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+        fixStyle: 'inline-type-imports',
+      },
+    ],
   },
 };

--- a/server/src/books/application/books-category.service.ts
+++ b/server/src/books/application/books-category.service.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import HttpException from 'src/utils/httpException';
 
-import Book from '../domain/book';
+import type Book from '../domain/book';
 import { findByCategory } from '../domain/books.repository';
 
 const getBooksByCategory = async (

--- a/server/src/books/application/books-detail.service.ts
+++ b/server/src/books/application/books-detail.service.ts
@@ -2,7 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import HttpException from 'src/utils/httpException';
 
-import Book from '../domain/book';
+import type Book from '../domain/book';
 import { findWithCategory } from '../domain/books.repository';
 
 const getDetailBook = async (id: number): Promise<Book> => {

--- a/server/src/books/application/books-new-release.service.ts
+++ b/server/src/books/application/books-new-release.service.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import HttpException from 'src/utils/httpException';
 
-import Book from '../domain/book';
+import type Book from '../domain/book';
 import { findByNewRelease } from '../domain/books.repository';
 
 export const getAllBooksByNewRelease = async (

--- a/server/src/books/domain/books.repository.ts
+++ b/server/src/books/domain/books.repository.ts
@@ -1,4 +1,4 @@
-import { RowDataPacket } from 'mysql2';
+import { type RowDataPacket } from 'mysql2';
 
 import logger from 'src/config/logger';
 

--- a/server/src/books/web/books-detail.controller.ts
+++ b/server/src/books/web/books-detail.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { type Request, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { ResponseHandler } from 'src/utils/responseHandler';
 

--- a/server/src/books/web/books-list.controller.ts
+++ b/server/src/books/web/books-list.controller.ts
@@ -1,6 +1,6 @@
 /* eslint-disable consistent-return */
 /* eslint-disable camelcase */
-import { Request, Response } from 'express';
+import { type Request, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { parseBoolean } from 'src/utils/parseBoolean';
 import { ResponseHandler } from 'src/utils/responseHandler';

--- a/server/src/category/domain/category.repository.ts
+++ b/server/src/category/domain/category.repository.ts
@@ -1,4 +1,4 @@
-import { RowDataPacket } from 'mysql2';
+import { type RowDataPacket } from 'mysql2';
 import { doQuery } from 'src/database/mariadb';
 
 import Category from './category';

--- a/server/src/category/web/category-list.controller.ts
+++ b/server/src/category/web/category-list.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { type Request, type Response } from 'express';
 
 import { StatusCodes } from 'http-status-codes';
 

--- a/server/src/database/mariadb.ts
+++ b/server/src/database/mariadb.ts
@@ -1,4 +1,4 @@
-import { createPool, Connection } from 'mysql2/promise';
+import { createPool, type Connection } from 'mysql2/promise';
 import dotenv from 'dotenv';
 
 dotenv.config();

--- a/server/src/users/domain/user.repository.ts
+++ b/server/src/users/domain/user.repository.ts
@@ -1,4 +1,4 @@
-import { ResultSetHeader, RowDataPacket } from 'mysql2';
+import { type ResultSetHeader, type RowDataPacket } from 'mysql2';
 import logger from 'src/config/logger';
 
 import { doQuery } from 'src/database/mariadb';

--- a/server/src/users/reset/web/password-request.controller.ts
+++ b/server/src/users/reset/web/password-request.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { type Request, type Response } from 'express';
 
 import { StatusCodes } from 'http-status-codes';
 

--- a/server/src/users/reset/web/password-reset.controller.ts
+++ b/server/src/users/reset/web/password-reset.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { type Request, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { ResponseHandler } from 'src/utils/responseHandler';
 

--- a/server/src/users/signin/web/signin.controller.ts
+++ b/server/src/users/signin/web/signin.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { type Request, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
 import { ResponseHandler } from 'src/utils/responseHandler';

--- a/server/src/users/signup/web/signup.controller.ts
+++ b/server/src/users/signup/web/signup.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { type Request, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { ResponseHandler } from 'src/utils/responseHandler';
 

--- a/server/src/utils/responseHandler.ts
+++ b/server/src/utils/responseHandler.ts
@@ -1,5 +1,5 @@
-import { Response } from 'express';
-import { StatusCodes } from 'http-status-codes';
+import { type Response } from 'express';
+import { type StatusCodes } from 'http-status-codes';
 
 import logger from 'src/config/logger';
 

--- a/server/src/utils/valiationHandler.ts
+++ b/server/src/utils/valiationHandler.ts
@@ -1,5 +1,5 @@
-import { NextFunction, Request, Response } from 'express';
-import { AnyZodObject, ZodError } from 'zod';
+import { type NextFunction, type Request, type Response } from 'express';
+import { type AnyZodObject, ZodError } from 'zod';
 
 export const validateHandler = <T extends AnyZodObject>(schema: T) => async (
   req: Request,


### PR DESCRIPTION
## 작업 내용 (Content)
TypeScirpt 모듈을 가져올 때 안정성을 보장 할 수 없습니다. 실제로 가져온 함수나 값이 실제로는 가져 오지 않는 타입일 수도 있습니다.
TypeScript. 4.5에 [inline type qualifiers](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names) 기능이 추가되어 Import 인라인 내에 `type`을 지정 할 수 있습니다.

## 링크 (Links)
- [type Modifiers on Import Names](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names)
- [Consistent Type Imports and Exports: Why and How](https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요? 
- [x] PR 리뷰 가능한 크기를 유지하셨나요?

