### PR TITLE
feat: MariaDB connection pool 개선 - 유휴 연결 시간 제한

### DIFF
--- a/server/src/database/mariadb.ts
+++ b/server/src/database/mariadb.ts
@@ -12,6 +12,7 @@ export const connectionPromise = createPool({
   dateStrings: true,
   waitForConnections: true,
   connectionLimit: 10,
+  idleTimeout: 30000,
 });
 
 export const doQuery = async <R>(doWork: (connection: Connection) => Promise<R>): Promise<R> => {


### PR DESCRIPTION
## 작업 내용 (Content)
- MariaDB connection pool에 유휴 연결 시간 제한 (idleTimeout) 속성을 추가했습니다.
- server/src/database/mariadb.ts 파일에 idleTimeout: 30000 속성 추가 (유휴 연결 시간 30초)

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요? 
- [x] PR 리뷰 가능한 크기를 유지하셨나요?

