### PR TITLE
좋아요 취소 기능 - JWT 인증 및 에러 처리 개선

### DIFF
--- a/server/src/likes/application/cancel-like.service.ts
+++ b/server/src/likes/application/cancel-like.service.ts
@@ -1,10 +1,14 @@
 import { StatusCodes } from 'http-status-codes';
 import HttpException from 'src/utils/httpException';
 
+import { validateToken } from 'src/users/jwt/jwt.provider';
+
 import { deleteByUserIdAndLikedBookId } from '../domain/likes.repository';
 
-export const cancelLike = async (userId: number, likedBookId: number): Promise<boolean> => {
+export const cancelLike = async (accessToken: any, likedBookId: number): Promise<boolean> => {
+  const { userId } = validateToken(accessToken);
   const canceledLike = await deleteByUserIdAndLikedBookId(userId, likedBookId);
+
   if (!canceledLike) {
     throw new HttpException('좋아요 취소에 실패했습니다.', StatusCodes.BAD_REQUEST);
   }

--- a/server/src/likes/web/cancel-like.controller.ts
+++ b/server/src/likes/web/cancel-like.controller.ts
@@ -5,8 +5,9 @@ import { StatusCodes } from 'http-status-codes';
 
 import { cancelLike } from '../application/cancel-like.service';
 
-const cancelLikeHandler = ({ params: { id }, body: { userId } }: Request, res: Response) => {
-  ResponseHandler(() => cancelLike(userId, Number(id)), StatusCodes.OK, res);
+const cancelLikeHandler = ({ params: { id }, headers }: Request, res: Response) => {
+  const accessToken = headers.authorization;
+  ResponseHandler(() => cancelLike(accessToken, Number(id)), StatusCodes.OK, res);
 };
 
 export default cancelLikeHandler;


### PR DESCRIPTION
- 좋아요 취소 기능을 사용자 인증과 연동했습니다.
  - cancelLike 서비스에서 사용자 ID 를 받는 방식을 엑세스 토큰으로 변경했습니다.
  - users/jwt/jwt.provider.ts 의 validateToken 함수를 사용하여 엑세스 토큰을 검증하고 사용자 ID 를 추출합니다.
  - cancel-like.controller.ts 에서 요청 헤더에서 엑세스 토큰을 가져오도록 수정했습니다.

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요? 
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?

