### PR TITLE
주문 테스트 데이터 및 서비스 로직 개선

### DIFF
--- a/server/src/fixture/orders.fixture.ts
+++ b/server/src/fixture/orders.fixture.ts
@@ -1,0 +1,60 @@
+import Delivery from 'src/delivery/domain/delivery';
+import Order from 'src/orders/domain/order';
+
+export const orders = [
+  {
+    id: 1,
+    bookTitle: '어린왕자',
+    totalQuantity: 3,
+    totalPrice: 6000,
+    userId: 0,
+    delivery: {
+      id: 0,
+      address: '강원도 춘천시 동내면 대룡산길 227-314 24408 한국',
+      contact: '010-1234-5667',
+      receiver: '홍길동',
+    },
+    deliveryId: 0,
+    createdAt: '2024-03-14T15:59:31.520Z',
+  },
+  {
+    id: 2,
+    bookTitle: '어린왕자',
+    totalQuantity: 3,
+    totalPrice: 6000,
+    userId: 0,
+    delivery: {
+      id: 0,
+      address: '강원도 춘천시 동내면 대룡산길 227-314 24408 한국',
+      contact: '010-1234-5667',
+      receiver: '홍길동',
+    },
+    deliveryId: 0,
+    createdAt: '2024-03-14T15:59:31.520Z',
+  },
+];
+
+export const mockOrders = [
+  new Order({
+    id: 1,
+    bookTitle: 'Book 1',
+    totalQuantity: 2,
+    totalPrice: 20,
+    delivery: new Delivery({
+      address: '123 Street',
+      receiver: 'John Doe',
+      contact: '1234567890',
+    }),
+  }),
+  new Order({
+    id: 2,
+    bookTitle: 'Book 2',
+    totalQuantity: 1,
+    totalPrice: 15,
+    delivery: new Delivery({
+      address: '456 Avenue',
+      receiver: 'Jane Smith',
+      contact: '9876543210',
+    }),
+  }),
+];

--- a/server/src/fixture/orders.fixture.ts
+++ b/server/src/fixture/orders.fixture.ts
@@ -58,3 +58,5 @@ export const mockOrders = [
     }),
   }),
 ];
+
+export const orderDetailMock = [{ author: '걍구두', bookId: 2, bookTitle: '신델렐라', price: 20000, quantity: 3 }];

--- a/server/src/orders/application/orders-detail.service.test.ts
+++ b/server/src/orders/application/orders-detail.service.test.ts
@@ -1,0 +1,41 @@
+import HttpException from 'src/utils/httpException';
+
+import { StatusCodes } from 'http-status-codes';
+
+import { orderDetailMock } from 'src/fixture/orders.fixture';
+
+import { findAllWithOrderId } from '../domain/order.repository';
+import { getDetailOrders } from './orders-detail.service';
+
+jest.mock('../domain/order.repository');
+
+describe('orderDetail Service', () => {
+  describe('getDetailOrders', () => {
+    const ORDER_ID = 1;
+    const NOT_FOUNT_ID = 9999;
+
+    beforeEach(() => {
+      (findAllWithOrderId as jest.Mock).mockReturnValue(orderDetailMock);
+    });
+    context('장바구니에 주문 목록 상품을 선택하면', () => {
+      it('주문 목록 상품을 반환한다.', async () => {
+        const order = await getDetailOrders(ORDER_ID);
+
+        expect(order).toStrictEqual([
+          { author: '걍구두', bookId: 2, bookTitle: '신델렐라', price: 20000, quantity: 3 },
+        ]);
+      });
+    });
+
+    context('장바구니에 주문 목록 상품이 존재하지 않으면', () => {
+      beforeEach(() => {
+        (findAllWithOrderId as jest.Mock).mockReturnValue([]);
+      });
+      it('error를 던져야 한다', async () => {
+        await expect(getDetailOrders(NOT_FOUNT_ID)).rejects.toThrow(
+          new HttpException('주문 된 상품을 찾을 수 없습니다.', StatusCodes.NOT_FOUND),
+        );
+      });
+    });
+  });
+});

--- a/server/src/orders/application/orders-list.service.test.ts
+++ b/server/src/orders/application/orders-list.service.test.ts
@@ -1,0 +1,41 @@
+import { mockOrders } from 'src/fixture/orders.fixture';
+
+import { findAll } from '../domain/order.repository';
+import { getAllOrders } from './orders-list.service';
+
+jest.mock('../domain/order.repository.ts');
+
+describe('orderList Service', () => {
+  beforeEach(() => {
+    (findAll as jest.Mock).mockResolvedValue(mockOrders);
+  });
+
+  describe('getAllOrders', () => {
+    context('주문 목록을 조회하면', () => {
+      it('주문 목록 리스트를 반환한다.', async () => {
+        const orders = await getAllOrders();
+
+        expect(orders).toEqual([
+          {
+            address: '123 Street',
+            bookTitle: 'Book 1',
+            contact: '1234567890',
+            orderId: 1,
+            receiver: 'John Doe',
+            totalPrice: 20,
+            totalQuantity: 2,
+          },
+          {
+            address: '456 Avenue',
+            bookTitle: 'Book 2',
+            contact: '9876543210',
+            orderId: 2,
+            receiver: 'Jane Smith',
+            totalPrice: 15,
+            totalQuantity: 1,
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/server/src/orders/application/orders-list.service.test.ts
+++ b/server/src/orders/application/orders-list.service.test.ts
@@ -1,5 +1,9 @@
 import { mockOrders } from 'src/fixture/orders.fixture';
 
+import HttpException from 'src/utils/httpException';
+
+import { StatusCodes } from 'http-status-codes';
+
 import { findAll } from '../domain/order.repository';
 import { getAllOrders } from './orders-list.service';
 
@@ -35,6 +39,17 @@ describe('orderList Service', () => {
             totalQuantity: 1,
           },
         ]);
+      });
+    });
+
+    context('주문 목록에 존재하지 않으면', () => {
+      beforeEach(() => {
+        (findAll as jest.Mock).mockResolvedValue([]);
+      });
+      it('error를 던져야 한다', async () => {
+        await expect(getAllOrders()).rejects.toThrow(
+          new HttpException('주문 목록을 찾을 수 없습니다.', StatusCodes.NOT_FOUND),
+        );
       });
     });
   });

--- a/server/src/orders/application/orders-list.service.ts
+++ b/server/src/orders/application/orders-list.service.ts
@@ -1,7 +1,14 @@
+import HttpException from 'src/utils/httpException';
+
+import { StatusCodes } from 'http-status-codes';
+
 import { findAll } from '../domain/order.repository';
 
 export const getAllOrders = async () => {
   const orders = await findAll();
+  if (orders.length === 0) {
+    throw new HttpException('주문 목록을 찾을 수 없습니다.', StatusCodes.NOT_FOUND);
+  }
 
   const findOrder = orders.map((item) => {
     return {

--- a/server/src/orders/web/orders-list.controller.test.ts
+++ b/server/src/orders/web/orders-list.controller.test.ts
@@ -1,9 +1,39 @@
 import app from 'src/app';
 import request from 'supertest';
 
+import { StatusCodes } from 'http-status-codes';
+import HttpException from 'src/utils/httpException';
+
+import { getAllOrders } from '../application/orders-list.service';
+
+jest.mock('../application/orders-list.service.ts');
+
 describe('getAllOrdersHandler Controller', () => {
   describe('GET /orders', () => {
     context('주문 조회에 성공하면', () => {
+      beforeEach(() => {
+        (getAllOrders as jest.Mock).mockReturnValue([
+          {
+            address: '강원도 춘천시 동내면 대룡산길 227-314 24408 한국',
+            bookTitle: '어린왕자',
+            contact: '010-1234-5667',
+            orderId: 1,
+            receiver: '홍길동',
+            totalPrice: 6000,
+            totalQuantity: 3,
+          },
+          {
+            address: '강원도 춘천시 동내면 대룡산길 227-314 24408 한국',
+            bookTitle: '어린왕자',
+            contact: '010-1234-5667',
+            orderId: 2,
+            receiver: '홍길동',
+            totalPrice: 6000,
+            totalQuantity: 3,
+          },
+        ]);
+      });
+
       it('200 상태코드와 응답 메세지를 반환한다.', async () => {
         const { status, body } = await request(app).get('/orders');
 
@@ -28,6 +58,26 @@ describe('getAllOrdersHandler Controller', () => {
             totalQuantity: 3,
           },
         ]);
+      });
+    });
+
+    context('주문 조회 요청 실패 시', () => {
+      beforeEach(() => {
+        (getAllOrders as jest.Mock).mockRejectedValue(
+          new HttpException('주문 목록을 찾을 수 없습니다.', StatusCodes.NOT_FOUND),
+        );
+      });
+
+      it('404 상태코드와 에러 메세지를 반환한다', async () => {
+        const { status, body } = await request(app).get('/orders');
+
+        expect(status).toBe(404);
+        expect(body).toEqual({
+          message: '주문 목록을 찾을 수 없습니다.',
+          status: 404,
+          success: false,
+          timestamp: expect.any(String),
+        });
       });
     });
   });


### PR DESCRIPTION
## 작업 내용 (Content)
- 주문 테스트 데이터 (server/src/fixture/orders.fixture.ts) 를 정리했습니다.
  - 실제 주문 데이터와 모의 주문 데이터를 구분하기 위해 별도의 배열로 분리했습니다.
  - 실제 주문 데이터는 orders 배열에, 모의 주문 데이터는 mockOrders 배열에 저장합니다.
- 주문 목록 조회 서비스 (server/src/orders/application/orders-list.service.test.ts) 의 테스트 케이스를 작성했습니다.
  - findAll 함수를 모킹하여 테스트 데이터를 반환하도록 설정했습니다.
  - 테스트 케이스를 통해 서비스가 주문 목록을 정확하게 조회하는지 확인합니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
  - 예시
    - 코드 가독성을 위해 메서드를 추출하라
    - if-else 문을 if 문으로 분리하라
    - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
  - 예시
    - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
    - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
      이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요? 
- [x] PR 리뷰 가능한 크기를 유지하셨나요?

